### PR TITLE
Add rest of test suites for the IOKit suite

### DIFF
--- a/Scripts/iokit.py
+++ b/Scripts/iokit.py
@@ -197,8 +197,8 @@ functions = [
     ),
     ("IOServiceNameMatching", gen_encoding(CFMutableDictionaryRef, CONST(Encodings.char_ptr))),
     (
-        "IORegistryEntryGetRegistryEntryID", 
-        gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, OUT(POINTER(Encodings.uint64_t)))
+        "IORegistryEntryGetRegistryEntryID",
+        gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, OUT(POINTER(Encodings.uint64_t))),
     ),
     ("IORegistryEntryIDMatching", gen_encoding(CFMutableDictionaryRef, Encodings.uint64_t)),
     ("IORegistryEntryFromPath", gen_encoding(Encodings.io_registry_entry_t, Encodings.mach_port_t, CONST(Encodings.io_string_t_in))),
@@ -284,6 +284,7 @@ def IORegistryEntryGetParentEntry(
 # kern_return_t IOObjectRelease(io_object_t object);
 def IOObjectRelease(object: io_object_t) -> kern_return_t:  # pylint: disable=invalid-name
     raise NotImplementedError
+
 
 # bool_t IOIteratorIsValid(io_iterator_t iterator);
 def IOIteratorIsValid(iterator: io_iterator_t) -> bool:

--- a/Scripts/iokit.py
+++ b/Scripts/iokit.py
@@ -47,7 +47,7 @@ def CONST(type_: Union[type, bytes]):
 class Encodings:
     id = b"@"
     void = b"v"
-    boolean_t = b"B"
+    bool = b"B"
     unsigned_long = unsigned_long_long = uint64_t = b"Q"
     # For input, we use (const) char* pointers, as we do not need an exactly 128 byte buffer
     char_ptr = b"*"
@@ -160,7 +160,7 @@ functions = [
             OUT(POINTER(Encodings.io_registry_entry_t)),
         ),
     ),
-    ("IOIteratorIsValid", gen_encoding(Encodings.boolean_t, Encodings.io_iterator_t)),
+    ("IOIteratorIsValid", gen_encoding(Encodings.bool, Encodings.io_iterator_t)),
     ("IOObjectRelease", gen_encoding(Encodings.kern_return_t, Encodings.io_object_t)),
     # io_name_t is char[128]
     ("IORegistryEntryGetName", gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, OUT(Encodings.io_name_t_out))),
@@ -190,7 +190,7 @@ functions = [
         gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, CONST(Encodings.io_name_t_in), OUT(Encodings.io_string_t_out)),
     ),
     ("IORegistryEntryCopyPath", gen_encoding(CFStringRef, Encodings.io_registry_entry_t, CONST(Encodings.io_name_t_in))),
-    ("IOObjectConformsTo", gen_encoding(Encodings.boolean_t, Encodings.io_object_t, CONST(Encodings.io_name_t_in))),
+    ("IOObjectConformsTo", gen_encoding(Encodings.bool, Encodings.io_object_t, CONST(Encodings.io_name_t_in))),
     (
         "IORegistryEntryGetLocationInPlane",
         gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, CONST(Encodings.io_name_t_in), OUT(Encodings.io_name_t_out)),
@@ -286,7 +286,7 @@ def IOObjectRelease(object: io_object_t) -> kern_return_t:  # pylint: disable=in
     raise NotImplementedError
 
 # bool_t IOIteratorIsValid(io_iterator_t iterator);
-def IOIteratorIsValid(iterator: io_iterator_t) -> Encodings.boolean_t:
+def IOIteratorIsValid(iterator: io_iterator_t) -> bool:
     raise NotImplementedError
 
 
@@ -368,7 +368,7 @@ def IORegistryEntryCopyPath(entry: io_registry_entry_t, plane: bytes) -> str:  #
 
 
 # boolean_t IOObjectConformsTo(io_object_t object, const io_name_t className)
-def IOObjectConformsTo(object: io_object_t, className: bytes) -> Encodings.boolean_t:  # pylint: disable=invalid-name
+def IOObjectConformsTo(object: io_object_t, className: bytes) -> bool:  # pylint: disable=invalid-name
     raise NotImplementedError
 
 

--- a/Scripts/iokit.py
+++ b/Scripts/iokit.py
@@ -47,7 +47,7 @@ def CONST(type_: Union[type, bytes]):
 class Encodings:
     id = b"@"
     void = b"v"
-    bool = b"B"
+    boolean_t = b"B"
     unsigned_long = unsigned_long_long = uint64_t = b"Q"
     # For input, we use (const) char* pointers, as we do not need an exactly 128 byte buffer
     char_ptr = b"*"
@@ -160,6 +160,7 @@ functions = [
             OUT(POINTER(Encodings.io_registry_entry_t)),
         ),
     ),
+    ("IOIteratorIsValid", gen_encoding(Encodings.boolean_t, Encodings.io_iterator_t)),
     ("IOObjectRelease", gen_encoding(Encodings.kern_return_t, Encodings.io_object_t)),
     # io_name_t is char[128]
     ("IORegistryEntryGetName", gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, OUT(Encodings.io_name_t_out))),
@@ -189,13 +190,16 @@ functions = [
         gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, CONST(Encodings.io_name_t_in), OUT(Encodings.io_string_t_out)),
     ),
     ("IORegistryEntryCopyPath", gen_encoding(CFStringRef, Encodings.io_registry_entry_t, CONST(Encodings.io_name_t_in))),
-    ("IOObjectConformsTo", gen_encoding(Encodings.bool, Encodings.io_object_t, CONST(Encodings.io_name_t_in))),
+    ("IOObjectConformsTo", gen_encoding(Encodings.boolean_t, Encodings.io_object_t, CONST(Encodings.io_name_t_in))),
     (
         "IORegistryEntryGetLocationInPlane",
         gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, CONST(Encodings.io_name_t_in), OUT(Encodings.io_name_t_out)),
     ),
     ("IOServiceNameMatching", gen_encoding(CFMutableDictionaryRef, CONST(Encodings.char_ptr))),
-    ("IORegistryEntryGetRegistryEntryID", gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, OUT(Encodings.uint64_t))),
+    (
+        "IORegistryEntryGetRegistryEntryID", 
+        gen_encoding(Encodings.kern_return_t, Encodings.io_registry_entry_t, OUT(POINTER(Encodings.uint64_t)))
+    ),
     ("IORegistryEntryIDMatching", gen_encoding(CFMutableDictionaryRef, Encodings.uint64_t)),
     ("IORegistryEntryFromPath", gen_encoding(Encodings.io_registry_entry_t, Encodings.mach_port_t, CONST(Encodings.io_string_t_in))),
 ]
@@ -281,6 +285,10 @@ def IORegistryEntryGetParentEntry(
 def IOObjectRelease(object: io_object_t) -> kern_return_t:  # pylint: disable=invalid-name
     raise NotImplementedError
 
+# bool_t IOIteratorIsValid(io_iterator_t iterator);
+def IOIteratorIsValid(iterator: io_iterator_t) -> Encodings.boolean_t:
+    raise NotImplementedError
+
 
 # kern_return_t IORegistryEntryGetName(io_registry_entry_t entry, io_name_t name);
 def IORegistryEntryGetName(entry: io_registry_entry_t, name: pointer) -> tuple[kern_return_t, bytes]:  # pylint: disable=invalid-name
@@ -359,9 +367,9 @@ def IORegistryEntryCopyPath(entry: io_registry_entry_t, plane: bytes) -> str:  #
     raise NotImplementedError
 
 
-# # boolean_t IOObjectConformsTo(io_object_t object, const io_name_t className)
-# def IOObjectConformsTo(object: io_object_t, className: bytes) -> boolean_t:  # pylint: disable=invalid-name
-#     raise NotImplementedError
+# boolean_t IOObjectConformsTo(io_object_t object, const io_name_t className)
+def IOObjectConformsTo(object: io_object_t, className: bytes) -> Encodings.boolean_t:  # pylint: disable=invalid-name
+    raise NotImplementedError
 
 
 # kern_return_t IORegistryEntryGetLocationInPlane(io_registry_entry_t entry, const io_name_t plane, io_name_t location)

--- a/test_iokit.py
+++ b/test_iokit.py
@@ -23,9 +23,7 @@ def test_IOServiceMatching():
 
 def test_IOServiceNameMatching():
     matching = iokit.IOServiceNameMatching("IOResources".encode())
-    assert iokit.corefoundation_to_native(matching) == {
-        "IONameMatch": "IOResources"
-    }
+    assert iokit.corefoundation_to_native(matching) == {"IONameMatch": "IOResources"}
 
 
 def test_IOServiceGetMatchingServices():
@@ -87,12 +85,7 @@ def test_IORegistryEntryGetParentEntry():
 
     err, name = iokit.IORegistryEntryGetName(parent, None)
     assert err == 0
-    assert iokit.io_name_t_to_str(name) == subprocess \
-        .check_output(["sysctl", "hw.model"]) \
-        .decode() \
-        .split(": ")[1] \
-        .replace("\n", "") \
-        .strip()
+    assert iokit.io_name_t_to_str(name) == subprocess.check_output(["sysctl", "hw.model"]).decode().split(": ")[1].replace("\n", "").strip()
 
     err = iokit.IOObjectRelease(device)
     assert err == 0
@@ -113,12 +106,7 @@ def test_IORegistryEntryGetName():
 
 
 def test_IOObjectRelease():
-    err, iterator = iokit.IORegistryCreateIterator (
-            iokit.kIOMainPortDefault,
-            "IOService".encode(),
-            iokit.kNilOptions,
-            None
-        )
+    err, iterator = iokit.IORegistryCreateIterator(iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None)
     assert err == 0
 
     err = iokit.IOObjectRelease(iterator)
@@ -128,10 +116,7 @@ def test_IOObjectRelease():
 def test_IOObjectConformsTo():
     device = _get_IOResources()
 
-    assert iokit.IOObjectConformsTo(
-        device,
-        "IOResources".encode()
-    ) == True
+    assert iokit.IOObjectConformsTo(device, "IOResources".encode()) == True
 
 
 def test_IOObjectGetClass():
@@ -162,37 +147,24 @@ def test_IOObjectCopySuperclassForClass():
 
 
 def test_IOIteratorNext():
-    err, iterator = iokit.IORegistryCreateIterator (
-            iokit.kIOMainPortDefault,
-            "IOService".encode(),
-            iokit.kNilOptions,
-            None
-        )
+    err, iterator = iokit.IORegistryCreateIterator(iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None)
     assert err == 0
 
     obj = iokit.IOIteratorNext(iterator)
-    assert obj != 0 # 0 means the iterator handle is invalid
+    assert obj != 0  # 0 means the iterator handle is invalid
 
     err = iokit.IOObjectRelease(obj)
     assert err == 0
 
 
 def test_IOIteratorIsValid():
-    err, iterator = iokit.IORegistryCreateIterator (
-            iokit.kIOMainPortDefault,
-            "IOService".encode(),
-            iokit.kNilOptions,
-            None
-        )
+    err, iterator = iokit.IORegistryCreateIterator(iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None)
     assert err == 0
     assert iokit.IOIteratorIsValid(iterator) == True
 
 
 def test_IORegistryEntryFromPath():
-    device = iokit.IORegistryEntryFromPath (
-        iokit.kIOMainPortDefault,
-        "IOService:/IOResources".encode()
-    )
+    device = iokit.IORegistryEntryFromPath(iokit.kIOMainPortDefault, "IOService:/IOResources".encode())
     assert device != iokit.NULL
 
     err = iokit.IOObjectRelease(device)
@@ -200,17 +172,12 @@ def test_IORegistryEntryFromPath():
 
 
 def test_IORegistryEntryGetLocationInPlane():
-    device = iokit.IORegistryEntryFromPath (
-        iokit.kIOMainPortDefault,
-        "IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/PEG0@1/IOPP/PEGP@0".encode()
+    device = iokit.IORegistryEntryFromPath(
+        iokit.kIOMainPortDefault, "IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/PEG0@1/IOPP/PEGP@0".encode()
     )
     assert device != iokit.NULL
 
-    err, location = iokit.IORegistryEntryGetLocationInPlane (
-        device,
-        "IOService".encode(),
-        None
-    )
+    err, location = iokit.IORegistryEntryGetLocationInPlane(device, "IOService".encode(), None)
     assert err == 0
     assert location.replace(b"\x00", b"") == b"0"
 
@@ -218,11 +185,7 @@ def test_IORegistryEntryGetLocationInPlane():
 def test_IORegistryEntryGetPath():
     device = _get_IOResources()
 
-    err, path = iokit.IORegistryEntryGetPath (
-        device,
-        "IOService".encode(),
-        None
-    )
+    err, path = iokit.IORegistryEntryGetPath(device, "IOService".encode(), None)
     assert err == 0
     assert path.replace(b"\x00", b"") == b"IOService:/IOResources"
 
@@ -236,37 +199,26 @@ def test_IORegistryEntryCopyPath():
 
 def test_IORegistryEntryIDMatching():
     device = iokit.IORegistryEntryIDMatching(4294967578)
-    assert iokit.corefoundation_to_native (device) == {
-        "IORegistryEntryID": 4294967578
-    }
+    assert iokit.corefoundation_to_native(device) == {"IORegistryEntryID": 4294967578}
 
 
 def test_IORegistryEntryGetRegistryEntryID():
     device = _get_IOResources()
-    
-    err, obj_id = iokit.IORegistryEntryGetRegistryEntryID (
-            device,
-            None
-        )
+
+    err, obj_id = iokit.IORegistryEntryGetRegistryEntryID(device, None)
     assert err == 0
     assert obj_id == 4294967578
 
 
 def test_IORegistryEntryGetChildIterator():
     device = _get_IOResources()
-    
-    err, iterator = iokit.IORegistryEntryGetChildIterator (
-            device,
-            "IOService".encode(),
-            None
-        )
+
+    err, iterator = iokit.IORegistryEntryGetChildIterator(device, "IOService".encode(), None)
     assert err == 0
 
     interface = list(iokit.ioiterator_to_list(iterator))
 
-    err, props = iokit.IORegistryEntryCreateCFProperties (
-            interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions
-        )
+    err, props = iokit.IORegistryEntryCreateCFProperties(interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions)
     assert err == 0
     assert props.get("IOProviderClass") == "IOResources"
 
@@ -276,19 +228,14 @@ def test_IORegistryEntryGetChildIterator():
 
 
 def test_IORegistryCreateIterator():
-    err, iterator = iokit.IORegistryCreateIterator (
-            iokit.kIOMainPortDefault,
-            "IODeviceTree".encode(),
-            iokit.kIORegistryIterateRecursively,
-            None
-        )
+    err, iterator = iokit.IORegistryCreateIterator(
+        iokit.kIOMainPortDefault, "IODeviceTree".encode(), iokit.kIORegistryIterateRecursively, None
+    )
     assert err == 0
 
     interface = list(iokit.ioiterator_to_list(iterator))
 
-    err, props = iokit.IORegistryEntryCreateCFProperties (
-            interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions
-        )
+    err, props = iokit.IORegistryEntryCreateCFProperties(interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions)
     assert err == 0
     assert props.get("IOPlatformUUID") == "115C2C75-F539-52BE-90AF-EBBC65ED6CB8"
 
@@ -300,19 +247,12 @@ def test_IORegistryCreateIterator():
 def test_IORegistryEntryCreateIterator():
     device = _get_IOResources()
 
-    err, iterator = iokit.IORegistryEntryCreateIterator (
-            device,
-            "IOService".encode(),
-            iokit.kIORegistryIterateRecursively,
-            None
-        )
+    err, iterator = iokit.IORegistryEntryCreateIterator(device, "IOService".encode(), iokit.kIORegistryIterateRecursively, None)
     assert err == 0
 
     interface = list(iokit.ioiterator_to_list(iterator))
 
-    err, props = iokit.IORegistryEntryCreateCFProperties (
-            interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions
-        )
+    err, props = iokit.IORegistryEntryCreateCFProperties(interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions)
     assert err == 0
     assert props.get("IOProviderClass") == "IOResources"
 
@@ -324,12 +264,7 @@ def test_IORegistryEntryCreateIterator():
 def test_IORegistryIteratorEnterEntry():
     device = _get_IOResources()
 
-    err, iterator = iokit.IORegistryEntryCreateIterator (
-            device,
-            "IOService".encode(),
-            iokit.kIORegistryIterateRecursively,
-            None
-        )
+    err, iterator = iokit.IORegistryEntryCreateIterator(device, "IOService".encode(), iokit.kIORegistryIterateRecursively, None)
     assert err == 0
 
     err = iokit.IORegistryIteratorEnterEntry(iterator)
@@ -339,12 +274,7 @@ def test_IORegistryIteratorEnterEntry():
 def test_IORegistryIteratorExitEntry():
     device = _get_IOResources()
 
-    err, iterator = iokit.IORegistryCreateIterator (
-            iokit.kIOMainPortDefault,
-            "IOService".encode(),
-            iokit.kNilOptions,
-            None
-        )
+    err, iterator = iokit.IORegistryCreateIterator(iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None)
     assert err == 0
 
     rec_lvl = 0

--- a/test_iokit.py
+++ b/test_iokit.py
@@ -6,7 +6,9 @@ from Scripts import iokit
 def _get_IOResources():
     matching = iokit.IOServiceMatching("IOResources".encode())
 
-    err, iterator = iokit.IOServiceGetMatchingServices(iokit.kIOMasterPortDefault, matching, None)
+    err, iterator = iokit.IOServiceGetMatchingServices(
+        iokit.kIOMasterPortDefault, matching, None
+    )
     assert err == 0
     assert iterator is not None
 
@@ -34,7 +36,9 @@ def test_IOServiceGetMatchingServices():
 
 def test_IORegistryEntryCreateCFProperty():
     device = _get_IOResources()
-    cf_property = iokit.IORegistryEntryCreateCFProperty(device, "IOKit", iokit.kCFAllocatorDefault, 0)
+    cf_property = iokit.IORegistryEntryCreateCFProperty(
+        device, "IOKit", iokit.kCFAllocatorDefault, 0
+    )
 
     result = iokit.corefoundation_to_native(cf_property)
     assert isinstance(result, str)
@@ -46,7 +50,9 @@ def test_IORegistryEntryCreateCFProperty():
 
 def test_IORegistryEntryCreateCFProperties():
     device = _get_IOResources()
-    err, cf_properties = iokit.IORegistryEntryCreateCFProperties(device, None, iokit.kCFAllocatorDefault, 0)
+    err, cf_properties = iokit.IORegistryEntryCreateCFProperties(
+        device, None, iokit.kCFAllocatorDefault, 0
+    )
     assert err == 0
 
     result = iokit.corefoundation_to_native(cf_properties)
@@ -80,13 +86,22 @@ def test_IORegistryEntrySearchCFProperty():
 def test_IORegistryEntryGetParentEntry():
     device = _get_IOResources()
 
-    err, parent = iokit.IORegistryEntryGetParentEntry(device, "IOService".encode(), None)
+    err, parent = iokit.IORegistryEntryGetParentEntry(
+        device, "IOService".encode(), None
+    )
     assert err == 0
     assert parent is not None
 
     err, name = iokit.IORegistryEntryGetName(parent, None)
     assert err == 0
-    assert iokit.io_name_t_to_str(name) == subprocess.check_output(["sysctl", "hw.model"]).decode().split(": ")[1].replace("\n", "").strip()
+    assert (
+        iokit.io_name_t_to_str(name)
+        == subprocess.check_output(["sysctl", "hw.model"])
+        .decode()
+        .split(": ")[1]
+        .replace("\n", "")
+        .strip()
+    )
 
     err = iokit.IOObjectRelease(device)
     assert err == 0
@@ -107,7 +122,9 @@ def test_IORegistryEntryGetName():
 
 
 def test_IOObjectRelease():
-    err, iterator = iokit.IORegistryCreateIterator(iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None)
+    err, iterator = iokit.IORegistryCreateIterator(
+        iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None
+    )
     assert err == 0
 
     err = iokit.IOObjectRelease(iterator)
@@ -143,12 +160,16 @@ def test_IOObjectCopyClass():
 
 def test_IOObjectCopySuperclassForClass():
     class_name = "IOService"
-    superclass_name = iokit.corefoundation_to_native(iokit.IOObjectCopySuperclassForClass(class_name))
+    superclass_name = iokit.corefoundation_to_native(
+        iokit.IOObjectCopySuperclassForClass(class_name)
+    )
     assert superclass_name == "IORegistryEntry"
 
 
 def test_IOIteratorNext():
-    err, iterator = iokit.IORegistryCreateIterator(iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None)
+    err, iterator = iokit.IORegistryCreateIterator(
+        iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None
+    )
     assert err == 0
 
     obj = iokit.IOIteratorNext(iterator)
@@ -159,13 +180,17 @@ def test_IOIteratorNext():
 
 
 def test_IOIteratorIsValid():
-    err, iterator = iokit.IORegistryCreateIterator(iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None)
+    err, iterator = iokit.IORegistryCreateIterator(
+        iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None
+    )
     assert err == 0
     assert iokit.IOIteratorIsValid(iterator) == True
 
 
 def test_IORegistryEntryFromPath():
-    device = iokit.IORegistryEntryFromPath(iokit.kIOMainPortDefault, "IOService:/IOResources".encode())
+    device = iokit.IORegistryEntryFromPath(
+        iokit.kIOMainPortDefault, "IOService:/IOResources".encode()
+    )
     assert device != iokit.NULL
 
     err = iokit.IOObjectRelease(device)
@@ -173,31 +198,19 @@ def test_IORegistryEntryFromPath():
 
 
 def test_IORegistryEntryGetLocationInPlane():
-    err, matched = iokit.IOServiceGetMatchingServices (
-            iokit.kIOMainPortDefault,
-            {
-                "IOPropertyMatch": [
-                    {
-                        "processor-number": 0
-                    },
-                    {
-                        "logical-cpu-id": 0
-                    }
-                ]
-            },
-            None
-        )
+    err, matched = iokit.IOServiceGetMatchingServices(
+        iokit.kIOMainPortDefault,
+        {"IOPropertyMatch": [{"processor-number": 0}, {"logical-cpu-id": 0}]},
+        None,
+    )
     assert err == 0
 
     iters = list(iokit.ioiterator_to_list(matched))
-    err, location = iokit.IORegistryEntryGetLocationInPlane (
-            iters[0],
-            b"IOService",
-            None
-        )
+    err, location = iokit.IORegistryEntryGetLocationInPlane(
+        iters[0], b"IOService", None
+    )
     assert err == 0
     assert location.replace(b"\x00", b"") == b"0"
-
 
     for i in iters:
         err = iokit.IOObjectRelease(i)
@@ -234,12 +247,10 @@ def test_IORegistryEntryGetRegistryEntryID():
 
 def test_IORegistryEntryGetChildIterator():
     device = _get_IOResources()
-    
-    err, iterator = iokit.IORegistryEntryGetChildIterator (
-            device,
-            "IOService".encode(),
-            None
-        )
+
+    err, iterator = iokit.IORegistryEntryGetChildIterator(
+        device, "IOService".encode(), None
+    )
     assert err == 0
 
     err = iokit.IOObjectRelease(iterator)
@@ -250,19 +261,19 @@ def test_IORegistryEntryGetChildIterator():
 
 
 def test_IORegistryCreateIterator():
-    err, iterator = iokit.IORegistryCreateIterator (
-            iokit.kIOMainPortDefault,
-            "IODeviceTree".encode(),
-            iokit.kIORegistryIterateRecursively,
-            None
-        )
+    err, iterator = iokit.IORegistryCreateIterator(
+        iokit.kIOMainPortDefault,
+        "IODeviceTree".encode(),
+        iokit.kIORegistryIterateRecursively,
+        None,
+    )
     assert err == 0
 
     interface = list(iokit.ioiterator_to_list(iterator))
 
-    err, props = iokit.IORegistryEntryCreateCFProperties (
-            interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions
-        )
+    err, props = iokit.IORegistryEntryCreateCFProperties(
+        interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions
+    )
     assert err == 0
     assert props.get("IOPlatformUUID") != None
 
@@ -274,12 +285,16 @@ def test_IORegistryCreateIterator():
 def test_IORegistryEntryCreateIterator():
     device = _get_IOResources()
 
-    err, iterator = iokit.IORegistryEntryCreateIterator(device, "IOService".encode(), iokit.kIORegistryIterateRecursively, None)
+    err, iterator = iokit.IORegistryEntryCreateIterator(
+        device, "IOService".encode(), iokit.kIORegistryIterateRecursively, None
+    )
     assert err == 0
 
     interface = list(iokit.ioiterator_to_list(iterator))
 
-    err, props = iokit.IORegistryEntryCreateCFProperties(interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions)
+    err, props = iokit.IORegistryEntryCreateCFProperties(
+        interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions
+    )
     assert err == 0
     assert props.get("IOProviderClass") == "IOResources"
 
@@ -291,7 +306,9 @@ def test_IORegistryEntryCreateIterator():
 def test_IORegistryIteratorEnterEntry():
     device = _get_IOResources()
 
-    err, iterator = iokit.IORegistryEntryCreateIterator(device, "IOService".encode(), iokit.kIORegistryIterateRecursively, None)
+    err, iterator = iokit.IORegistryEntryCreateIterator(
+        device, "IOService".encode(), iokit.kIORegistryIterateRecursively, None
+    )
     assert err == 0
 
     err = iokit.IORegistryIteratorEnterEntry(iterator)
@@ -301,7 +318,9 @@ def test_IORegistryIteratorEnterEntry():
 def test_IORegistryIteratorExitEntry():
     device = _get_IOResources()
 
-    err, iterator = iokit.IORegistryCreateIterator(iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None)
+    err, iterator = iokit.IORegistryCreateIterator(
+        iokit.kIOMainPortDefault, "IOService".encode(), iokit.kNilOptions, None
+    )
     assert err == 0
 
     rec_lvl = 0
@@ -319,4 +338,3 @@ def test_IORegistryIteratorExitEntry():
 
             rec_lvl -= 1
             assert iokit.IORegistryIteratorExitEntry(iter) == 0
-

--- a/test_iokit.py
+++ b/test_iokit.py
@@ -1,11 +1,14 @@
+import subprocess
 from Scripts import iokit
 
 
 def _get_IOResources():
     matching = iokit.IOServiceMatching("IOResources".encode())
+
     err, iterator = iokit.IOServiceGetMatchingServices(iokit.kIOMasterPortDefault, matching, None)
     assert err == 0
     assert iterator is not None
+
     results = list(iokit.ioiterator_to_list(iterator))
     assert len(results) == 1
     return results[0]
@@ -15,6 +18,13 @@ def test_IOServiceMatching():
     matching = iokit.IOServiceMatching("IOResources".encode())
     assert iokit.corefoundation_to_native(matching) == {
         "IOProviderClass": "IOResources",
+    }
+
+
+def test_IOServiceNameMatching():
+    matching = iokit.IOServiceNameMatching("IOResources".encode())
+    assert iokit.corefoundation_to_native(matching) == {
+        "IONameMatch": "IOResources"
     }
 
 
@@ -77,7 +87,12 @@ def test_IORegistryEntryGetParentEntry():
 
     err, name = iokit.IORegistryEntryGetName(parent, None)
     assert err == 0
-    assert iokit.io_name_t_to_str(name) == "J413AP"
+    assert iokit.io_name_t_to_str(name) == subprocess \
+        .check_output(["sysctl", "hw.model"]) \
+        .decode() \
+        .split(": ")[1] \
+        .replace("\n", "") \
+        .strip()
 
     err = iokit.IOObjectRelease(device)
     assert err == 0
@@ -95,6 +110,28 @@ def test_IORegistryEntryGetName():
 
     err = iokit.IOObjectRelease(device)
     assert err == 0
+
+
+def test_IOObjectRelease():
+    err, iterator = iokit.IORegistryCreateIterator (
+            iokit.kIOMainPortDefault,
+            "IOService".encode(),
+            iokit.kNilOptions,
+            None
+        )
+    assert err == 0
+
+    err = iokit.IOObjectRelease(iterator)
+    assert err == 0
+
+
+def test_IOObjectConformsTo():
+    device = _get_IOResources()
+
+    assert iokit.IOObjectConformsTo(
+        device,
+        "IOResources".encode()
+    ) == True
 
 
 def test_IOObjectGetClass():
@@ -122,3 +159,206 @@ def test_IOObjectCopySuperclassForClass():
     class_name = "IOService"
     superclass_name = iokit.corefoundation_to_native(iokit.IOObjectCopySuperclassForClass(class_name))
     assert superclass_name == "IORegistryEntry"
+
+
+def test_IOIteratorNext():
+    err, iterator = iokit.IORegistryCreateIterator (
+            iokit.kIOMainPortDefault,
+            "IOService".encode(),
+            iokit.kNilOptions,
+            None
+        )
+    assert err == 0
+
+    obj = iokit.IOIteratorNext(iterator)
+    assert obj != 0 # 0 means the iterator handle is invalid
+
+    err = iokit.IOObjectRelease(obj)
+    assert err == 0
+
+
+def test_IOIteratorIsValid():
+    err, iterator = iokit.IORegistryCreateIterator (
+            iokit.kIOMainPortDefault,
+            "IOService".encode(),
+            iokit.kNilOptions,
+            None
+        )
+    assert err == 0
+    assert iokit.IOIteratorIsValid(iterator) == True
+
+
+def test_IORegistryEntryFromPath():
+    device = iokit.IORegistryEntryFromPath (
+        iokit.kIOMainPortDefault,
+        "IOService:/IOResources".encode()
+    )
+    assert device != iokit.NULL
+
+    err = iokit.IOObjectRelease(device)
+    assert err == 0
+
+
+def test_IORegistryEntryGetLocationInPlane():
+    device = iokit.IORegistryEntryFromPath (
+        iokit.kIOMainPortDefault,
+        "IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/PEG0@1/IOPP/PEGP@0".encode()
+    )
+    assert device != iokit.NULL
+
+    err, location = iokit.IORegistryEntryGetLocationInPlane (
+        device,
+        "IOService".encode(),
+        None
+    )
+    assert err == 0
+    assert location.replace(b"\x00", b"") == b"0"
+
+
+def test_IORegistryEntryGetPath():
+    device = _get_IOResources()
+
+    err, path = iokit.IORegistryEntryGetPath (
+        device,
+        "IOService".encode(),
+        None
+    )
+    assert err == 0
+    assert path.replace(b"\x00", b"") == b"IOService:/IOResources"
+
+
+def test_IORegistryEntryCopyPath():
+    device = _get_IOResources()
+
+    path = iokit.IORegistryEntryCopyPath(device, "IOService".encode())
+    assert path == "IOService:/IOResources"
+
+
+def test_IORegistryEntryIDMatching():
+    device = iokit.IORegistryEntryIDMatching(4294967578)
+    assert iokit.corefoundation_to_native (device) == {
+        "IORegistryEntryID": 4294967578
+    }
+
+
+def test_IORegistryEntryGetRegistryEntryID():
+    device = _get_IOResources()
+    
+    err, obj_id = iokit.IORegistryEntryGetRegistryEntryID (
+            device,
+            None
+        )
+    assert err == 0
+    assert obj_id == 4294967578
+
+
+def test_IORegistryEntryGetChildIterator():
+    device = _get_IOResources()
+    
+    err, iterator = iokit.IORegistryEntryGetChildIterator (
+            device,
+            "IOService".encode(),
+            None
+        )
+    assert err == 0
+
+    interface = list(iokit.ioiterator_to_list(iterator))
+
+    err, props = iokit.IORegistryEntryCreateCFProperties (
+            interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions
+        )
+    assert err == 0
+    assert props.get("IOProviderClass") == "IOResources"
+
+    for i in interface:
+        err = iokit.IOObjectRelease(i)
+        assert err == 0
+
+
+def test_IORegistryCreateIterator():
+    err, iterator = iokit.IORegistryCreateIterator (
+            iokit.kIOMainPortDefault,
+            "IODeviceTree".encode(),
+            iokit.kIORegistryIterateRecursively,
+            None
+        )
+    assert err == 0
+
+    interface = list(iokit.ioiterator_to_list(iterator))
+
+    err, props = iokit.IORegistryEntryCreateCFProperties (
+            interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions
+        )
+    assert err == 0
+    assert props.get("IOPlatformUUID") == "115C2C75-F539-52BE-90AF-EBBC65ED6CB8"
+
+    for i in interface:
+        err = iokit.IOObjectRelease(i)
+        assert err == 0
+
+
+def test_IORegistryEntryCreateIterator():
+    device = _get_IOResources()
+
+    err, iterator = iokit.IORegistryEntryCreateIterator (
+            device,
+            "IOService".encode(),
+            iokit.kIORegistryIterateRecursively,
+            None
+        )
+    assert err == 0
+
+    interface = list(iokit.ioiterator_to_list(iterator))
+
+    err, props = iokit.IORegistryEntryCreateCFProperties (
+            interface[0], None, iokit.kCFAllocatorDefault, iokit.kNilOptions
+        )
+    assert err == 0
+    assert props.get("IOProviderClass") == "IOResources"
+
+    for i in interface:
+        err = iokit.IOObjectRelease(i)
+        assert err == 0
+
+
+def test_IORegistryIteratorEnterEntry():
+    device = _get_IOResources()
+
+    err, iterator = iokit.IORegistryEntryCreateIterator (
+            device,
+            "IOService".encode(),
+            iokit.kIORegistryIterateRecursively,
+            None
+        )
+    assert err == 0
+
+    err = iokit.IORegistryIteratorEnterEntry(iterator)
+    assert err == 0
+
+
+def test_IORegistryIteratorExitEntry():
+    device = _get_IOResources()
+
+    err, iterator = iokit.IORegistryCreateIterator (
+            iokit.kIOMainPortDefault,
+            "IOService".encode(),
+            iokit.kNilOptions,
+            None
+        )
+    assert err == 0
+
+    rec_lvl = 0
+    entry = 0
+    while True:
+        entry = iokit.IOIteratorNext(entry)
+
+        if entry:
+            rec_lvl += 1
+            assert iokit.IORegistryIteratorEnterEntry(iter) == 0
+
+        else:
+            if rec_lvl == 0:
+                break
+
+            rec_lvl -= 1
+            assert iokit.IORegistryIteratorExitEntry(iter) == 0

--- a/test_iokit.py
+++ b/test_iokit.py
@@ -320,5 +320,3 @@ def test_IORegistryIteratorExitEntry():
             rec_lvl -= 1
             assert iokit.IORegistryIteratorExitEntry(iter) == 0
 
-
-test_IORegistryEntryGetLocationInPlane()


### PR DESCRIPTION
This PR fills in the rest of the test suites by adding tests for the following functions:

- `IOIteratorNext()`
- `IOIteratorIsValid()`
- `IOObjectRelease()`
- `IORegistryEntryGetChildIterator()`
- `IORegistryCreateIterator()`
- `IORegistryEntryCreateIterator()`
- `IORegistryEntryGetPath()`
- `IORegistryEntryCopyPath()`
- `IOObjectConformsTo()`
- `IORegistryEntryGetLocationInPlane()`
- `IOServiceNameMatching()`
- `IORegistryEntryGetRegistryEntryID()`
- `IORegistryEntryIDMatching()`
- `IORegistryEntryFromPath()`
- `IORegistryIteratorEnterEntry()`
- `IORegistryIteratorExitEntry()`

This PR also includes miscellaneous fixes:

- Encoding was invalid for `IORegistryEntryGetRegistryEntryID()` — it's meant to be `OUT(POINTER(uint64_t))` instead of `OUT(uint64_t)`;
- `test_IORegistryEntryGetParentEntry()` now invokes `sysctl hw.model` to properly match against the value returned by `IORegistryGetName()`; and
- Functions that return bool can simply be annotated as `def func(...) -> bool`

For the 3rd aforementioned point, I am not 100% certain if this is acceptable and accurate. The test suites where a function returns bool seems to run just fine, and does return `True`. 
 
 
 EDIT: I wrote `IORegistryEntryIDMatching` as being the method that has a parameter of type `OUT(POINTER(uint64_t))`, but it's actually `IORegistryEntryGetRegistryEntryID()`. Apologies!